### PR TITLE
Upgrading the node runtime from 8.x to 10.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       AWS_PROFILE:
       TF_VAR_release:
       TF_VAR_repo:
-    image: hashicorp/terraform:0.11.15
+    image: hashicorp/terraform:0.11.14
     volumes:
       - ~/.aws:/root/.aws
       - ./:/terraform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       AWS_PROFILE:
       TF_VAR_release:
       TF_VAR_repo:
-    image: hashicorp/terraform:0.11.14
+    image: hashicorp/terraform:0.11.15
     volumes:
       - ~/.aws:/root/.aws
       - ./:/terraform

--- a/events/index.js
+++ b/events/index.js
@@ -63,7 +63,7 @@ const getAttachment = (event) => {
       title:    title,
     };
   }
-}
+};
 
 const actionPost = (payload) => {
   return slack.dialog.open({
@@ -103,7 +103,7 @@ const actionSync = async (payload) => {
       },
     ],
   });
-}
+};
 
 const submitPost = async (payload) => {
   const time      = moment(payload.action_ts * 1000 || +new Date());

--- a/events/main.tf
+++ b/events/main.tf
@@ -142,7 +142,7 @@ resource aws_lambda_function callback {
   handler          = "index.handler"
   memory_size      = 1024
   role             = "${data.aws_iam_role.role.arn}"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   source_code_hash = "${data.archive_file.package.output_base64sha256}"
   tags             = "${var.tags}"
   timeout          = 3

--- a/invite/index.js
+++ b/invite/index.js
@@ -14,7 +14,7 @@ const getToken = async (options) => {
   const secret = await secretsmanager.getSecretValue(options).promise();
   token = JSON.parse(secret.SecretString).SLACK_LEGACY_TOKEN;
   return token;
-}
+};
 
 const invite = async (options) => {
   const res = await request({
@@ -69,5 +69,5 @@ const handle = async (record) => {
 
 exports.handler = async (event) => {
   await Promise.resolve(token || getToken({SecretId: SLACK_SECRET}));
-  return await Promise.all(event.Records.map(handle))
+  return await Promise.all(event.Records.map(handle));
 };

--- a/invite/main.tf
+++ b/invite/main.tf
@@ -21,7 +21,7 @@ resource aws_lambda_function callback {
   handler          = "index.handler"
   memory_size      = 1024
   role             = "${data.aws_iam_role.role.arn}"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   source_code_hash = "${data.archive_file.package.output_base64sha256}"
   tags             = "${var.tags}"
   timeout          = 10

--- a/mods/main.tf
+++ b/mods/main.tf
@@ -29,7 +29,7 @@ resource aws_lambda_function callback {
   handler          = "index.handler"
   memory_size      = 1024
   role             = "${data.aws_iam_role.role.arn}"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   source_code_hash = "${data.archive_file.package.output_base64sha256}"
   tags             = "${var.tags}"
   timeout          = 10

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,13 +158,13 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
-      "version": "2.493.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.493.0.tgz",
-      "integrity": "sha512-xLNpjiNgLZoXqwmLQ+czP3UQzeRgsutpG1KGfVUaj/3giqEElpn0wYkwhkJt4Glm9xf3jgzAdbFEDYM7u+Llxg==",
+      "version": "2.554.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.554.0.tgz",
+      "integrity": "sha512-23EQhz4pCRwzCRRc40deQgoO2ddCT4ylfoVPAuQKOQA8SZqMCWYGkntHjtNWVMd5zIJzHYt26qo8s8zsorc7Rg==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.13",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
@@ -193,9 +193,9 @@
       }
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -242,8 +242,8 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
+        "base64-js": "1.3.1",
+        "ieee754": "1.1.13",
         "isarray": "1.0.0"
       }
     },
@@ -730,9 +730,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "inherits": {
       "version": "2.0.3",
@@ -902,9 +902,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
-      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
+      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
       "requires": {
         "moment": "2.24.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "@slack/client": "^4.8.0",
-    "aws-sdk": "^2.384.0",
+    "aws-sdk": "^2.554.0",
     "googleapis": "^36.0.0",
-    "moment-timezone": "^0.5.23",
+    "moment-timezone": "^0.5.27",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "slackend": "^1.3.2"

--- a/welcome/main.tf
+++ b/welcome/main.tf
@@ -173,7 +173,7 @@ resource aws_lambda_function team_join {
   handler          = "index.handler"
   memory_size      = 1024
   role             = "${data.aws_iam_role.role.arn}"
-  runtime          = "nodejs8.10"
+  runtime          = "nodejs10.x"
   source_code_hash = "${data.archive_file.package.output_base64sha256}"
   tags             = "${var.tags}"
   timeout          = 3


### PR DESCRIPTION
AWS sent is an email

> We are contacting you as we have identified that your AWS Account currently has one or more Lambda functions using Node.js 8.10, which will reach its EOL at the end of 2019.
